### PR TITLE
fixed rest endpoints that take more than one input

### DIFF
--- a/test/test_script.sh
+++ b/test/test_script.sh
@@ -2,8 +2,44 @@
 #
 #run some basic test transactions on new chain
 
+INIT=0
 TEST_CHAIN_BIN='../build/release/tlcs'
+POSITIONAL_ARGS=()
 
+while [[ $# -gt 0 ]]; do
+	case $1 in
+	-init | --init_new_chain)
+		INIT=1
+		shift # past argument
+		shift # past value
+		;;
+	-b | --binary)
+		TEST_CHAIN_BIN="$2"
+		shift # past argument
+		shift # past value
+		;;
+	--default)
+		DEFAULT=YES
+		shift # past argument
+		;;
+	-* | --*)
+		echo "Unknown option $1"
+		exit 1
+		;;
+	*)
+		POSITIONAL_ARGS+=("$1") # save positional arg
+		shift                   # past argument
+		;;
+	esac
+done
+
+set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
+
+if [[ ${INIT} == "1" ]]; then
+  (cd ..; make init)
+fi
+
+echo "Adding accounts"
 echo "race draft rival universe maid cheese steel logic crowd fork comic easy truth drift tomorrow eye buddy head time cash swing swift midnight borrow" | $TEST_CHAIN_BIN keys add kevin --recover
 echo "all victory hero talent forget twice quote you office vacant sleep kangaroo disorder scorpion humble gorilla coast pudding edge garlic bid dutch excuse magic" | $TEST_CHAIN_BIN keys add alice --recover
 echo "quick rack fancy cruel knee early summer clock group apology excuse file voice album fold cave garbage student awake twenty stereo argue draw human" | $TEST_CHAIN_BIN keys add ahmad --recover
@@ -13,9 +49,11 @@ echo "quick rack fancy cruel knee early summer clock group apology excuse file v
 #echo 'from_user = "kevin"' >>~/.tlcs/config/resend.toml
 #echo 'chain_id = "test-chain"' >>~/.tlcs/config/resend.toml
 
+echo "Getting drand data"
 TEST_LATEST_ROUND=$(curl -s https://api.drand.sh/dbd506d6ef76e5f386f41c651dcb808c5bcbd75471cc4eafa3f4df7ad4e4c493/public/latest | cut -d, -f1 | cut -d: -f2)
 TEST_UNIX_TIME=$(date +%s)
 
+echo "Submitting transactions"
 $TEST_CHAIN_BIN tx kevin timelock keypair $(expr $TEST_LATEST_ROUND + 600) 1 $(expr $TEST_UNIX_TIME + 120)
 
 sleep 10

--- a/tlcs/scripts/init.sh
+++ b/tlcs/scripts/init.sh
@@ -3,11 +3,11 @@
 set -eux
 
 rm -rf ~/.tlcs
-cargo run -- init test
+cargo run --bin tlcs -- init test
 
-cargo run -- add-genesis-account cosmos1syavy2npfyt9tcncdtsdzf7kny9lh777pahuux 34uatom
-cargo run -- add-genesis-account cosmos1skgmlw2j4qupafzcg5qvacd76mfzfe69la0hxz 53uatom
-cargo run -- add-genesis-account cosmos1gc308w6mg7skucsdxdjehhewr4aetwq24zf92m 50uatom
+cargo run --bin tlcs -- add-genesis-account cosmos1syavy2npfyt9tcncdtsdzf7kny9lh777pahuux 34uatom
+cargo run --bin tlcs -- add-genesis-account cosmos1skgmlw2j4qupafzcg5qvacd76mfzfe69la0hxz 53uatom
+cargo run --bin tlcs -- add-genesis-account cosmos1gc308w6mg7skucsdxdjehhewr4aetwq24zf92m 50uatom
 
 touch ~/.tlcs/config/resend.toml
 echo 'tendermint_url = "http://localhost:26657"' >>~/.tlcs/config/resend.toml

--- a/x/timelock/src/client/rest.rs
+++ b/x/timelock/src/client/rest.rs
@@ -93,8 +93,7 @@ pub async fn get_contributions_by_round_and_scheme<
     H: Handler<M, SK, G>,
     G: Genesis,
 >(
-    Path(round): Path<u64>,
-    Path(scheme): Path<u32>,
+    Path((round, scheme)): Path<(u64, u32)>,
     _pagination: Query<Pagination>,
     State(app): State<BaseApp<SK, PSK, M, BK, AK, H, G>>,
 ) -> Result<Json<QueryAllContributionsResponse>, Error> {
@@ -212,8 +211,7 @@ pub async fn get_keypairs_by_round_and_scheme<
     H: Handler<M, SK, G>,
     G: Genesis,
 >(
-    Path(round): Path<u64>,
-    Path(scheme): Path<u32>,
+    Path((round, scheme)): Path<(u64, u32)>,
     _pagination: Query<Pagination>,
     State(app): State<BaseApp<SK, PSK, M, BK, AK, H, G>>,
 ) -> Result<Json<QueryAllKeyPairsResponse>, Error> {
@@ -327,7 +325,7 @@ async fn endpoint_info() -> &'static str {
      \t /tlcs/timelock/v1beta1/keypairs\n\
      \t /tlcs/timelock/v1beta1/keypairs/round/<round>\n\
      \t /tlcs/timelock/v1beta1/keypairs/time/<time>\n\
-     \t /tlcs/timelock/v1beta1/keypairs/round_and_scheme/<round>/:scheme>\n\
+     \t /tlcs/timelock/v1beta1/keypairs/round_and_scheme/<round>/<scheme>\n\
      \t /tlcs/timelock/v1beta1/loe_data\n\
      \t /tlcs/timelock/v1beta1/loe_data/round/<round>\n\
      \t /tlcs/timelock/v1beta1/loe_data_needed\n\

--- a/x/timelock/src/handler.rs
+++ b/x/timelock/src/handler.rs
@@ -4,7 +4,7 @@ use ibc_proto::protobuf::Protobuf;
 use prost::Message as ProstMessage;
 use store::StoreKey;
 use tendermint_proto::abci::RequestBeginBlock;
-use tracing::info;
+//use tracing::info;
 
 use crate::{
     proto::tlcs::v1beta1::{QueryRoundRequest, QueryRoundSchemeRequest, QueryTimeRequest},
@@ -39,9 +39,6 @@ impl<SK: StoreKey> Handler<SK> {
         ctx: &mut TxContext<DB, SK>,
         _request: RequestBeginBlock,
     ) {
-        //let _ = set_last_processed_round(ctx, 4183720);
-        ////return;
-
         // TODO: Get this from the number of validators. For now we'll just set it here
         //let _ = set_contribution_threshold(ctx, 2);
         //let contribution_threshold = get_contribution_threshold(ctx);
@@ -51,14 +48,11 @@ impl<SK: StoreKey> Handler<SK> {
 
         let (need_pub_keys, need_secret_keys) = self.keeper.get_empty_keypairs(ctx);
 
-        info!("BEGINBLOCKER: need pubkeys: {:?}", need_pub_keys.len());
+        //info!("BEGINBLOCKER: need pubkeys: {:?}", need_pub_keys.len());
         self.keeper
             .make_public_keys(ctx, need_pub_keys, block_time, contribution_threshold);
 
-        info!(
-            "BEGINBLOCKER: need secret keys: {:?}",
-            need_secret_keys.len()
-        );
+        //info!( "BEGINBLOCKER: need secret keys: {:?}", need_secret_keys.len());
         self.keeper.make_secret_keys(ctx, need_secret_keys);
     }
 


### PR DESCRIPTION
Rest endpoint code is slightly different when there are more than one input.

Instead of Path(param): Path<u32>

you have

Path((param, param)): Path<u32, u32>