### PR TITLE
added mechanism to submit keyshares from beginblocker

### DIFF
--- a/x/timelock/src/handler.rs
+++ b/x/timelock/src/handler.rs
@@ -28,7 +28,7 @@ impl<SK: StoreKey> Handler<SK> {
         msg: &Message,
     ) -> Result<(), AppError> {
         match msg {
-            Message::NewProcess(msg) => self.keeper.open_new_process(ctx, self.config.clone(), msg),
+            Message::NewProcess(msg) => self.keeper.open_new_process(ctx, msg),
             Message::MultiNewProcess(msg) => self.keeper.open_multi_new_process(ctx, msg),
             Message::Participate(msg) => self.keeper.append_contribution(ctx, msg),
             Message::SubmitLoeData(msg) => self.keeper.append_loe_data(&mut ctx.as_any(), msg),
@@ -55,6 +55,8 @@ impl<SK: StoreKey> Handler<SK> {
 
         //info!( "BEGINBLOCKER: need secret keys: {:?}", need_secret_keys.len());
         self.keeper.make_secret_keys(ctx, need_secret_keys);
+
+        let _ = self.keeper.make_keyshares(ctx, self.config.clone());
     }
 
     pub fn handle_query<DB: Database>(

--- a/x/timelock/src/lib.rs
+++ b/x/timelock/src/lib.rs
@@ -20,3 +20,9 @@ const LOE_PUBLIC_KEY: &str = "83cf0f2896adee7eb8b5f01fcad3912212c437e0073e911fb9
 pub const LOE_GENESIS_TIME: u32 = 1692803367;
 pub const LOE_PERIOD: u32 = 3;
 const SECURITY_PARAM: usize = 10;
+
+// Key Prefixes
+const CONTRIBUTION_THRESHOLD_KEY: [u8; 1] = [0];
+const PARTICIPANT_DATA_KEY: [u8; 1] = [1];
+const KEYPAIR_DATA_KEY: [u8; 1] = [2];
+const LOE_DATA_KEY: [u8; 1] = [3];

--- a/x/timelock/src/utils.rs
+++ b/x/timelock/src/utils.rs
@@ -103,7 +103,7 @@ pub async fn broadcast_tx_commit(client: HttpClient, raw_tx: TxRaw) -> Result<()
 }
 
 // NOTE: we're assuming here that the app has an auth module which handles this query
-fn get_account_latest(address: AccAddress, node: Url) -> Result<QueryAccountResponse> {
+pub fn get_account_latest(address: AccAddress, node: Url) -> Result<QueryAccountResponse> {
     let query = QueryAccountRequest { address };
 
     run_query::<QueryAccountResponse, RawQueryAccountResponse>(


### PR DESCRIPTION
The keyshares were being generated directly from the open_process keeper in the past but that was problematic when too many keypairs were requested at one time.
Hence, I've moved the functionality to the beginblocker and each node will submit one keyshare per block, depending on need and will avoid the problem of the signature sequence.